### PR TITLE
Fixes #23: uninitialized constant 'Cocaine'

### DIFF
--- a/lib/paperclip-compression/jpeg.rb
+++ b/lib/paperclip-compression/jpeg.rb
@@ -12,9 +12,9 @@ module PaperclipCompression
     def make
       begin
         @config.process_file? ? process_file : unprocessed_tempfile
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         raise Paperclip::Error, "JPEGTRAN : There was an error processing #{@basename}" if @config.whiny
-      rescue Cocaine::CommandNotFoundError => e
+      rescue Terrapin::CommandNotFoundError => e
         raise Paperclip::Errors::CommandNotFoundError.new("Could not run 'jpegtran'. Please install jpegtran.")
       end
     end

--- a/lib/paperclip-compression/png.rb
+++ b/lib/paperclip-compression/png.rb
@@ -12,9 +12,9 @@ module PaperclipCompression
     def make
       begin
         @config.process_file? ? process_file : unprocessed_tempfile
-      rescue Cocaine::ExitStatusError => e
+      rescue Terrapin::ExitStatusError => e
         raise Paperclip::Error, "OPTIPNG : There was an error processing #{@basename}" if @config.whiny
-      rescue Cocaine::CommandNotFoundError => e
+      rescue Terrapin::CommandNotFoundError => e
         raise Paperclip::Errors::CommandNotFoundError.new("Could not run 'optipng'. Please install optipng.")
       end
     end

--- a/paperclip-compression.gemspec
+++ b/paperclip-compression.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
   s.test_files    = s.files.grep(%r{^(test|spec|features)/})
   s.require_paths = ['lib']
 
-  s.add_runtime_dependency 'paperclip', '>= 5.2.1'
+  s.add_runtime_dependency 'paperclip', '>= 6.1.0'
   s.add_runtime_dependency 'os', ['~> 1.0.0']
 
   s.add_development_dependency 'bundler', '~> 1.3'


### PR DESCRIPTION
As of 321807573451b0e656a40a12979a7684e7dab2f6, cocaine was renamed 'terrapin' and paperclip was updated to use that name instead.  This changes updates paperclip-compression to use 'Terrapin' instead of Cocaine, which resolves the following errors that arise when Terrapin fails:

uninitialized constant PaperclipCompression::Jpeg::Cocaine
uninitialized constant PaperclipCompression::Png::Cocaine